### PR TITLE
Add Akephalos to Production Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Guide for using AI to solve hard problems in complex codebases.
 
 ### Production Tools
 
+- **[Akephalos](https://github.com/sunnja69/akephalos)**: Local-first, markdown-first `.akephalos` passport for portable agent preferences, tool notes, rules, project context, and durable memories across agents, MCP clients, and machines via plain files/Git.
 - **Claude Code**: Auto-compact context management
 - **Cursor**: Rules-based context engineering
 


### PR DESCRIPTION
Adds Akephalos to the Production Tools section.

Akephalos is a local-first, markdown-first `.akephalos` passport for carrying preferences, tool notes, rules, project context, and durable memories across agents and MCP-compatible tools. Sync is via plain files/Git.

Accuracy notes:
- early v0.1/MVP-stage project
- local MCP stdio server available from the public repo
- no hosted account, cloud sync, dashboard, OAuth, vector DB, blockchain, or npm availability claim here
