### PR TITLE
Add MFS to Context Engineering Systems & Kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Principles for building reliable agents: share full context and avoid fragile pa
 - **[Project Context Records (PCR)](https://github.com/hyf0/project-context-records)**: A context-engineering methodology that keeps a durable, repo-versioned archive of a project's meta-context (the why, architecture, and maintainer decisions) so AI collaborators inherit its judgment instead of re-deriving it
 - **[interview-prep-template](https://github.com/AbhiK189/interview-prep-template)**: A three-layer context-engineering template (immutable sources → agent-maintained wiki → operating-manual file) where the agent synthesizes raw material into reusable answers, frameworks, and scored debriefs that compound over time
 - **[Practical Guide to Context Engineering](https://github.com/WakeUp-Jin/Practical-Guide-to-Context-Engineering)**: A practical, hands-on guide (in Chinese) to context engineering for LLM applications
+- **[MFS](https://github.com/zilliztech/mfs)**: A context harness that unifies code, docs, chat, databases, and object stores into one file-like, searchable namespace (`ls`/`cat`/`grep` + hybrid semantic search), so agents pull context incrementally instead of injecting it all up front; self-hosted and local-first (local ONNX embeddings + Milvus, no API key)
 
 ### Development Frameworks
 


### PR DESCRIPTION
Adds **[MFS](https://github.com/zilliztech/mfs)** (Apache-2.0). MFS unifies code, docs, chat, databases, and object stores into one file-like, searchable namespace (`ls`/`cat`/`grep` + hybrid semantic search), so agents pull context incrementally rather than injecting everything up front — the same retrieval-as-tool-call idea this list catalogs. Close in spirit to existing entries like `kit` (codebase mapping + code search) and `RepoPrompt`, with a self-hosted, local-first angle (local ONNX embeddings + Milvus, no API key).