### PR TITLE
Add GoodMemory to memory and compression resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ RL-trained models that run up to 8 parallel searches per turn to retrieve code c
 ### Memory & Compression
 
 - **[claude-mem](https://github.com/thedotmack/claude-mem)**: Persistent cross-session memory for Claude Code that automatically captures, compresses, and re-injects context across sessions
+- **[GoodMemory](https://github.com/hjqcan/GoodMemory)**: Local-first, auditable memory layer for AI apps and coding agents, with Codex/Claude Code host integration, a standalone MCP server, TypeScript/Python clients, and SQLite or Postgres storage
 - **[LeanCTX (lean-ctx)](https://github.com/yvgude/lean-ctx)**: Context intelligence layer for AI agents — a single local Rust binary that decides what agents read, remember, and save; 60–90% fewer tokens, with 76 MCP tools and local-first design
 - **[headroom](https://github.com/chopratejas/headroom)**: Compresses tool outputs/logs before they reach the LLM, saving 60-95% of tokens
 - **[Accordion](https://github.com/a-Fig/Accordion)**: A pi extension that renders an agent's entire context window as a live "map" and folds (reversibly compacts) less-relevant blocks in the background via pluggable "conductors" that rank block relevance, instead of lossy all-or-nothing compaction

--- a/README_CN.md
+++ b/README_CN.md
@@ -232,6 +232,7 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 ### 记忆与压缩
 
 - **[claude-mem](https://github.com/thedotmack/claude-mem)**：面向 Claude Code 的跨会话持久记忆，自动捕获、压缩并在会话间回注上下文
+- **[GoodMemory](https://github.com/hjqcan/GoodMemory)**：面向 AI 应用与编程智能体的本地优先、可审计记忆层，支持 Codex/Claude Code 主机集成、独立 MCP 服务、TypeScript/Python 客户端，以及 SQLite 或 Postgres 存储
 - **[LeanCTX (lean-ctx)](https://github.com/yvgude/lean-ctx)**：面向 AI agent 的上下文智能层——单个本地 Rust 二进制决定 agent 读取、记忆与保存什么；token 减少 60–90%，提供 76 个 MCP 工具，本地优先
 - **[headroom](https://github.com/chopratejas/headroom)**：在内容进入 LLM 前压缩工具输出/日志，节省 60-95% 的 token
 - **[Accordion](https://github.com/a-Fig/Accordion)**：一个 pi 扩展,将 agent 的整个上下文窗口渲染为实时"地图",并通过可插拔的"conductor"(对各块相关性打分)在后台折叠(可逆地压缩)相关性较低的块,替代有损的全量压缩


### PR DESCRIPTION
## Summary

- add GoodMemory to the English `Memory & Compression` section
- add the matching Chinese entry to `记忆与压缩`

GoodMemory belongs here because it provides a local-first, auditable memory layer for AI applications and coding agents, with Codex/Claude Code host integration, a standalone MCP server, TypeScript/Python clients, and SQLite/Postgres storage.

## Validation

- confirmed GoodMemory was not already listed in either README
- verified the repository URL returns HTTP 200
- ran `git diff --check`
