### PR TITLE
Add "Compaction is a lossy operation" to Featured Articles (EN + CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ Parallel sub-agent architecture that avoids fabrication when processing many ite
 
 RL-trained models that run up to 8 parallel searches per turn to retrieve code context an order of magnitude faster while minimizing context pollution.
 
+### Compaction Is a Lossy Operation
+
+- https://loopandretry.github.io/posts/compaction-is-a-lossy-operation/?ref=awesome-ctxeng
+
+Why compacting an agent's context is lossy compression, not free summarization — what survives, what silently drops, and how it degrades long multi-turn runs.
+
 ## 📑 Research Papers
 
 ### Survey Papers

--- a/README_CN.md
+++ b/README_CN.md
@@ -122,6 +122,12 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 用强化学习训练、每轮最多 8 路并行检索的模型，在最小化 context 污染的同时将代码上下文检索速度提升一个数量级。
 
 
+### 压缩是一种有损操作
+
+- https://loopandretry.github.io/posts/compaction-is-a-lossy-operation/?ref=awesome-ctxeng
+
+为什么压缩智能体的 context 是有损压缩，而非免费的摘要——哪些信息被保留、哪些被悄悄丢弃，以及它如何逐渐劣化长的多轮运行。
+
 ## 📑 研究论文
 
 ### 综述论文


### PR DESCRIPTION
Adds one practitioner essay to **📖 Featured Articles** (with the required CN mirror in `README_CN.md`).

Link: https://loopandretry.github.io/posts/compaction-is-a-lossy-operation/

Why it fits: maps directly to the **compression** pillar in CONTRIBUTING. The post treats context compaction as *lossy compression* rather than free summarization — what survives, what silently drops, and how that degradation compounds across long multi-turn agent runs. Same practitioner lane as the existing Chroma *Context Rot* and dbreunig context-failure entries.

Both files updated to stay in sync:
- `README.md` → new `### Compaction Is a Lossy Operation` entry at the end of Featured Articles.
- `README_CN.md` → mirrored `### 压缩是一种有损操作` entry in 精选文章.

Disclosure: I write this blog; submitting because it's genuinely on-topic, not a marketing page. Link is live (200).