### PR TITLE
Add screenpipe to context engineering systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ RL-trained models that run up to 8 parallel searches per turn to retrieve code c
 
 - **[Prompt Engineering Guide](https://github.com/dair-ai/Prompt-Engineering-Guide)** ⭐76.1k: Comprehensive guide and resources for prompt engineering, context engineering, RAG, and AI agents
 - **[get-shit-done (GSD)](https://github.com/gsd-build/get-shit-done)** ⭐64.5k: Meta-prompting, context engineering and spec-driven development system for Claude Code
+- **[screenpipe](https://github.com/screenpipe/screenpipe)** ⭐19.9k: Source-available, local-first work-context layer that captures screen, audio, input, browser, and meeting activity for agent retrieval through MCP, REST, and CLI
 - **[Agent Skills for Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering)** ⭐16.7k: Collection of Agent Skills for context engineering and multi-agent architectures
 - **[Context Engineering Intro](https://github.com/coleam00/context-engineering-intro)** ⭐13.5k: Context engineering introduction and methodology for AI coding assistants
 - **[Context-Engineering (jasontang-ai)](https://github.com/jasontang-ai/Context-Engineering)** ⭐9.1k: Karpathy-inspired first-principles handbook for context engineering
@@ -335,4 +336,3 @@ Special thanks to all contributors and the research community advancing the fiel
 **Maintained by**: [yzfly](https://github.com/yzfly) | **云中江树（微信公众号: 云中江树）**
 
 *If you find this repository helpful, please consider giving it a ⭐!*
-

--- a/README_CN.md
+++ b/README_CN.md
@@ -193,6 +193,7 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 
 - **[提示工程指南 (Prompt Engineering Guide)](https://github.com/dair-ai/Prompt-Engineering-Guide)** ⭐76.1k：提示工程、上下文工程、RAG 与 AI 智能体的综合指南与资源合集
 - **[get-shit-done (GSD)](https://github.com/gsd-build/get-shit-done)** ⭐64.5k：面向 Claude Code 的元提示、上下文工程与规范驱动开发系统
+- **[screenpipe](https://github.com/screenpipe/screenpipe)** ⭐19.9k：源码可用、本地优先的工作上下文层，捕获屏幕、音频、输入、浏览器和会议活动，并通过 MCP、REST 和 CLI 向智能体提供可检索的工作证据
 - **[Agent Skills for Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering)** ⭐16.7k：面向上下文工程与多代理架构的 Agent Skills 集合
 - **[Context工程入门](https://github.com/coleam00/context-engineering-intro)** ⭐13.5k：面向 AI 编程助手的上下文工程入门方法论
 - **[Context-Engineering（jasontang-ai）](https://github.com/jasontang-ai/Context-Engineering)** ⭐9.1k：受 Karpathy 启发的上下文工程第一性原理手册


### PR DESCRIPTION
Adds screenpipe to Context Engineering Systems & Kits in both the English and Chinese READMEs.

screenpipe is a direct context-engineering input layer: it captures real work context across screen, audio, input, browser, and meetings, then exposes searchable evidence to agents through MCP, REST, and CLI.

The wording explicitly says source-available and avoids describing the current license as open source. Placement follows the section star ordering using the current 19.9k GitHub star count.

Disclosure: I maintain screenpipe.

Validation:
- both language files contain exactly one matching entry
- git diff --check
- repository, website, and documentation links return HTTP 200