### PR TITLE
Add Hexis to context engineering systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ RL-trained models that run up to 8 parallel searches per turn to retrieve code c
 - **[interview-prep-template](https://github.com/AbhiK189/interview-prep-template)**: A three-layer context-engineering template (immutable sources → agent-maintained wiki → operating-manual file) where the agent synthesizes raw material into reusable answers, frameworks, and scored debriefs that compound over time
 - **[Practical Guide to Context Engineering](https://github.com/WakeUp-Jin/Practical-Guide-to-Context-Engineering)**: A practical, hands-on guide (in Chinese) to context engineering for LLM applications
 - **[MFS](https://github.com/zilliztech/mfs)**: A context harness that unifies code, docs, chat, databases, and object stores into one file-like, searchable namespace (`ls`/`cat`/`grep` + hybrid semantic search), so agents pull context incrementally instead of injecting it all up front; self-hosted and local-first (local ONNX embeddings + Milvus, no API key)
+- **[Hexis](https://github.com/Bevel-Software/Hexis)**: Git-backed platform for skills, tools, and context for AI agents, with Git review workflows, role-based access, encrypted secrets, and remote MCP access
 
 ### Development Frameworks
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -222,6 +222,7 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 - **[Project Context Records (PCR)](https://github.com/hyf0/project-context-records)**：一套上下文工程方法论，在仓库内持久化、版本化地存档项目的「元上下文」（缘由、架构、维护者决策），让 AI 协作者继承项目判断力，而非反复重新推导
 - **[interview-prep-template](https://github.com/AbhiK189/interview-prep-template)**：三层上下文工程模板（不可变原始素材 → agent 维护的 wiki → 运行手册文件），由 agent 把原始素材合成为可复用的答案、框架与带评分的复盘，并随每次面试持续累积变强
 - **[Practical Guide to Context Engineering](https://github.com/WakeUp-Jin/Practical-Guide-to-Context-Engineering)**：面向大模型应用的上下文工程实战指南（中文）
+- **[Hexis](https://github.com/Bevel-Software/Hexis)**：面向 AI Agent 的 Git 驱动技能、工具与上下文平台，支持 Git 评审流程、基于角色的访问控制、加密密钥存储与远程 MCP 接入
 
 ### 开发框架
 


### PR DESCRIPTION
Adds Hexis to Context Engineering Systems and Kits in both the English and Chinese READMEs.

Hexis is a Git-backed platform for skills, tools, and context for AI agents. It belongs here because it makes shared agent context versioned and reviewable, scopes access by role, and exposes it to agents over MCP.

The repository link is public and active, and the two language versions remain in sync.