### PR TITLE
Add LWC to Memory & Compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ RL-trained models that run up to 8 parallel searches per turn to retrieve code c
 - **[Cognee](https://github.com/topoteretes/cognee)**: Open-source AI memory platform giving agents persistent long-term memory via a self-hosted knowledge-graph engine
 - **[Graphiti](https://github.com/getzep/graphiti)**: Framework for building real-time, temporal knowledge graphs for AI agents (the engine behind Zep's memory)
 - **[Supermemory](https://github.com/supermemoryai/supermemory)**: Fast, scalable memory + context engine with a single Memory API; supports fully local runs
+- **[LWC](https://github.com/JanYork/llm-wiki-cli)**: Proactive, source-grounded project memory for coding agents, preserving immutable sources, citations, provenance, and atomic changesets with SQLite/FTS5 retrieval, optional document/code graphs, lifecycle hooks, and a bounded one-tool MCP interface
 
 ### Production Tools
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -242,6 +242,7 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 - **[Cognee](https://github.com/topoteretes/cognee)**：开源 AI 记忆平台，通过自托管知识图谱引擎为智能体提供跨会话的持久长期记忆
 - **[Graphiti](https://github.com/getzep/graphiti)**：为 AI 智能体构建实时、时序感知知识图谱的框架（Zep 记忆基础设施的核心引擎）
 - **[Supermemory](https://github.com/supermemoryai/supermemory)**：快速、可扩展的记忆与上下文引擎，提供统一 Memory API，支持完全本地运行
+- **[LWC](https://github.com/JanYork/llm-wiki-cli)**：面向编码智能体的主动式、来源可追溯项目记忆，保存不可变原始资料、引用、来源链与原子变更集，提供 SQLite/FTS5 检索、可选文档图与代码图、生命周期 Hook，以及受限的单工具 MCP 接口
 
 ### 生产工具
 


### PR DESCRIPTION
Adds [LWC](https://github.com/JanYork/llm-wiki-cli) to **Memory & Compression** in both the English and Chinese READMEs.

LWC is directly related to context engineering: it gives coding agents proactive, source-grounded project memory with immutable sources, citations, provenance, atomic changesets, SQLite/FTS5 retrieval, optional document and code graphs, lifecycle hooks, and a bounded one-tool MCP interface. The project is actively maintained, publicly accessible, and Apache-2.0 licensed.

Checks: both language versions contain exactly one synchronized entry, the project link returns HTTP 200, and `git diff --check` passes.