### PR TITLE
Add Agent QA to context engineering systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ RL-trained models that run up to 8 parallel searches per turn to retrieve code c
 - **[Context Engineering Kit](https://github.com/NeoLabHQ/context-engineering-kit)** ⭐1.2k: A context engineering skills toolkit
 - **[ACE (Agentic Context Engineering)](https://github.com/ace-agent/ace)** ⭐1.2k: Evolving language agents through agentic context engineering (ACE)
 - **[context-space](https://github.com/context-space/context-space)** ⭐812: Context engineering infrastructure built from MCPs and integrations
+- **[Agent QA](https://github.com/vostride/agent-qa)** ⭐772: Source-available QA agent that retains scoped test memory and failure evidence across natural-language web and mobile runs
 - **[Practical Guide to Context Engineering](https://github.com/WakeUp-Jin/Practical-Guide-to-Context-Engineering)** ⭐708: A practical, hands-on guide (in Chinese) to context engineering for LLM applications
 - **[get-shit-done (GSD)](https://github.com/gsd-build/get-shit-done)**: Meta-prompting and spec-driven development / context engineering system for Claude Code
 - **[GSD-2](https://github.com/gsd-build/gsd-2)**: Meta-prompting / context engineering system enabling long-running autonomous agent work

--- a/README_CN.md
+++ b/README_CN.md
@@ -205,6 +205,7 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 - **[Context工程工具包](https://github.com/NeoLabHQ/context-engineering-kit)** ⭐1.2k：上下文工程技能套件
 - **[ACE（智能体式上下文工程）](https://github.com/ace-agent/ace)** ⭐1.2k：智能体上下文工程（ACE），让语言代理自我进化
 - **[context-space](https://github.com/context-space/context-space)** ⭐812：从 MCP 与集成出发构建的上下文工程基础设施
+- **[Agent QA](https://github.com/vostride/agent-qa)** ⭐772：源码可用的 QA Agent，在自然语言 Web／移动端测试之间保留范围受控的测试记忆与失败证据
 - **[Practical Guide to Context Engineering](https://github.com/WakeUp-Jin/Practical-Guide-to-Context-Engineering)** ⭐708：面向大模型应用的上下文工程实战指南（中文）
 - **[get-shit-done (GSD)](https://github.com/gsd-build/get-shit-done)**：面向Claude Code的元提示与规范驱动开发／上下文工程系统
 - **[GSD-2](https://github.com/gsd-build/gsd-2)**：支持智能体长时自主工作的元提示／上下文工程系统


### PR DESCRIPTION
## Summary

Add Agent QA to **Context Engineering Systems & Kits** in both the English and Chinese READMEs, keeping the two versions synchronized and the star-ranked block ordered.

## Why it fits

Agent QA is a source-available QA agent for natural-language web and mobile tests. Its scoped persistent test memory carries verified flow knowledge and failure evidence across executions, allowing later runs to select useful context without treating an old action trace as the test oracle.

Repository: https://github.com/vostride/agent-qa

Agent QA currently has 772 GitHub stars. It uses FSL-1.1-ALv2, which converts to Apache-2.0 after two years.

## Validation

- `git diff --check`
- Agent QA appears once in each README with the same URL and equivalent descriptions
- star order remains `812 > 772 > 708`
- standard awesome-lint reports 125 repository-wide errors and 2 warnings; the new lines inherit the existing bold-link format that the linter flags throughout this block
