### PR TITLE
Add skillreaper

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ RL-trained models that run up to 8 parallel searches per turn to retrieve code c
 - **[Cognee](https://github.com/topoteretes/cognee)**: Open-source AI memory platform giving agents persistent long-term memory via a self-hosted knowledge-graph engine
 - **[Graphiti](https://github.com/getzep/graphiti)**: Framework for building real-time, temporal knowledge graphs for AI agents (the engine behind Zep's memory)
 - **[Supermemory](https://github.com/supermemoryai/supermemory)**: Fast, scalable memory + context engine with a single Memory API; supports fully local runs
+- **[skillreaper](https://github.com/thousandflowers/skillreaper)**: Measures what share of an agent's loaded context ever actually fires — skills, MCP servers, subagents, hooks — from session transcripts, then prunes the unused parts reversibly
 
 ### Production Tools
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -242,6 +242,7 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 - **[Cognee](https://github.com/topoteretes/cognee)**：开源 AI 记忆平台，通过自托管知识图谱引擎为智能体提供跨会话的持久长期记忆
 - **[Graphiti](https://github.com/getzep/graphiti)**：为 AI 智能体构建实时、时序感知知识图谱的框架（Zep 记忆基础设施的核心引擎）
 - **[Supermemory](https://github.com/supermemoryai/supermemory)**：快速、可扩展的记忆与上下文引擎，提供统一 Memory API，支持完全本地运行
+- **[skillreaper](https://github.com/thousandflowers/skillreaper)**：基于会话记录统计智能体加载的 context 中真正被调用的比例（技能、MCP 服务器、子智能体、hooks），并可逆地清理未使用的部分
 
 ### 生产工具
 


### PR DESCRIPTION
Adds skillreaper under Tools & Projects → Context Engineering Systems & Kits, in both `README.md` and `README_CN.md`.

**Why it belongs:** context engineering is usually framed as what to put *into* the window; skillreaper measures the opposite side — what an agent loads and never uses. It parses your own session transcripts, computes utilization per category (skills, MCP servers, subagents, hooks, always-loaded prose), prices the waste in tokens, and prunes the dead weight reversibly. Local only, nothing uploaded.

- Repo: https://github.com/thousandflowers/skillreaper
- License: MIT, actively maintained (first commit 2026-06-10, currently v0.5.0)
- Install: `npx skillreaper`, Homebrew, or static binaries for six platforms

Inclusion criteria: relevant (context management/compression), public, actively maintained, not already listed.