### PR TITLE
Add kgai to Context Engineering Systems & Kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ RL-trained models that run up to 8 parallel searches per turn to retrieve code c
 - **[interview-prep-template](https://github.com/AbhiK189/interview-prep-template)**: A three-layer context-engineering template (immutable sources → agent-maintained wiki → operating-manual file) where the agent synthesizes raw material into reusable answers, frameworks, and scored debriefs that compound over time
 - **[Practical Guide to Context Engineering](https://github.com/WakeUp-Jin/Practical-Guide-to-Context-Engineering)**: A practical, hands-on guide (in Chinese) to context engineering for LLM applications
 - **[MFS](https://github.com/zilliztech/mfs)**: A context harness that unifies code, docs, chat, databases, and object stores into one file-like, searchable namespace (`ls`/`cat`/`grep` + hybrid semantic search), so agents pull context incrementally instead of injecting it all up front; self-hosted and local-first (local ONNX embeddings + Milvus, no API key)
+- **[kgai](https://github.com/kgaidev/kgai)**: Local-first, append-only log of engineering decisions projected deterministically into a small knowledge graph, so coding agents recall just the current head decisions as bounded context (no embeddings in the hot path) while superseded paths stay queryable as dead ends
 
 ### Development Frameworks
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -222,6 +222,7 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 - **[Project Context Records (PCR)](https://github.com/hyf0/project-context-records)**：一套上下文工程方法论，在仓库内持久化、版本化地存档项目的「元上下文」（缘由、架构、维护者决策），让 AI 协作者继承项目判断力，而非反复重新推导
 - **[interview-prep-template](https://github.com/AbhiK189/interview-prep-template)**：三层上下文工程模板（不可变原始素材 → agent 维护的 wiki → 运行手册文件），由 agent 把原始素材合成为可复用的答案、框架与带评分的复盘，并随每次面试持续累积变强
 - **[Practical Guide to Context Engineering](https://github.com/WakeUp-Jin/Practical-Guide-to-Context-Engineering)**：面向大模型应用的上下文工程实战指南（中文）
+- **[kgai](https://github.com/kgaidev/kgai)**：本地优先、仅追加的工程决策日志，确定性投影为小型知识图谱，编码智能体只召回当前生效的头部决策作为有界上下文（热路径不用 embedding），被取代的决策和死路仍可查询
 
 ### 开发框架
 


### PR DESCRIPTION
We build kgai, an MIT-licensed, local-first append-only log of engineering decisions with a deterministic projection into a small knowledge graph, aimed at coding agents that need bounded decision recall rather than similarity search over past sessions. This adds one entry to Context Engineering Systems & Kits, in both README.md and README_CN.md so the two stay in sync. Happy to reword, shorten or move it to another section if that fits the list's conventions better.