### PR TITLE
Add trace-mcp to Memory & Compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,7 @@ Why compacting an agent's context is lossy compression, not free summarization �
 - **[skillreaper](https://github.com/thousandflowers/skillreaper)**: Measures what share of an agent's loaded context ever actually fires — skills, MCP servers, subagents, hooks — from session transcripts, then prunes the unused parts reversibly
 - **[LWC](https://github.com/JanYork/llm-wiki-cli)**: Proactive, source-grounded project memory for coding agents, preserving immutable sources, citations, provenance, and atomic changesets with SQLite/FTS5 retrieval, optional document/code graphs, lifecycle hooks, and a bounded one-tool MCP interface
 - **[billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh)**: Model-driven context compression (Active Context Pruning) for the DeepSeek Harness — the model decides when and what to compress
+- **[trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp)**: Local MCP server that serves a precomputed cross-language code graph instead of file reads — framework-aware edges link a PHP controller to the Vue page it renders, a DI decorator to its provider, an ORM call to the migration that defines the table (81 languages, 87 framework integrations), plus code-linked decision memory across sessions; on 60 merged PRs from six third-party repositories, review context drops from a median 13,595 to 1,326 input tokens
 
 ### Production Tools
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -266,6 +266,7 @@ Context工程是对大语言模型(LLM)信息负载的系统性优化。它包�
 - **[skillreaper](https://github.com/thousandflowers/skillreaper)**：基于会话记录统计智能体加载的 context 中真正被调用的比例（技能、MCP 服务器、子智能体、hooks），并可逆地清理未使用的部分
 - **[LWC](https://github.com/JanYork/llm-wiki-cli)**：面向编码智能体的主动式、来源可追溯项目记忆，保存不可变原始资料、引用、来源链与原子变更集，提供 SQLite/FTS5 检索、可选文档图与代码图、生命周期 Hook，以及受限的单工具 MCP 接口
 - **[billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh)**：面向 DeepSeek Harness 的模型驱动上下文压缩（Active Context Pruning）——由模型决定何时压缩、压缩什么
+- **[trace-mcp](https://github.com/nikolai-vysotskyi/trace-mcp)**：本地 MCP 服务器，以预先构建的跨语言代码图替代逐文件读取——框架感知的边会把 PHP 控制器连到它渲染的 Vue 页面、把依赖注入装饰器连到其 provider、把 ORM 调用连到定义该表的迁移文件（81 种语言、87 个框架集成），并提供与代码关联的跨会话决策记忆；在 6 个第三方仓库的 60 个已合并 PR 上，评审所需上下文从中位数 13,595 个输入 token 降到 1,326 个
 
 ### 生产工具
 


### PR DESCRIPTION
Adds trace-mcp to **Memory & Compression** in both `README.md` and `README_CN.md`, after `billion-context-dsh`, following the existing format.

Disclosure: I maintain it. It sits next to lean-ctx and headroom in that section, but reduces context a different way — those compress what the agent was going to read; trace-mcp answers the question from a graph so most of the reading never happens.

What is specific to it, and checkable:

- **Framework-aware edges across language boundaries.** `Inertia::render('Users/Show')` becomes a PHP→Vue edge, `@Injectable()` a DI edge, `$user->posts()` an edge to the table its migration defines. 81 languages, 87 framework integrations.
- **The benchmark is on repositories I do not own** — 60 merged PRs across six of them, median review context 1,326 input tokens against 13,595 for reading the changed files. Method and per-PR data: https://trace-mcp.com/pr-context-benchmark.html, including the five PRs where the graph did not help.

Happy to shorten either line, or to move the entry if you think MCP-based code navigation belongs under Tools & Projects rather than Memory & Compression.
